### PR TITLE
Add Databricks DLT fetch notebook

### DIFF
--- a/Databricks_DLT_fetch.ipynb
+++ b/Databricks_DLT_fetch.ipynb
@@ -1,0 +1,71 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Fetching data from Databricks Delta Live Table (DLT)\n",
+    "This notebook demonstrates how to connect to a Databricks workspace and load data from a Delta Live Table."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from pyspark.sql import SparkSession\n",
+    "\n",
+    "# Configure SparkSession for Databricks.\n",
+    "# In Databricks this is already available. When running outside\n",
+    "# of Databricks, provide the necessary connection details.\n",
+    "spark = SparkSession.builder.appName(\"dlt-fetch-example\").getOrCreate()\n",
+    "\n",
+    "# Name of the Delta Live Table to query\n",
+    "table_name = 'LIVE.my_dlt_table'\n",
+    "\n",
+    "df = spark.read.format('delta').table(table_name)\n",
+    "df.show()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Fetch pipeline information using Databricks SDK (optional)\n",
+    "Requires the `databricks-sdk` package and a Databricks personal access token."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Uncomment and configure the following if databricks-sdk is available\n",
+    "# from databricks.sdk import WorkspaceClient\n",
+    "#\n",
+    "# w = WorkspaceClient(host='https://<databricks-instance>', token='<databricks-token>')\n",
+    "#\n",
+    "# pipelines = w.pipelines.list()\n",
+    "# for p in pipelines:\n",
+    "#     print(p.name, p.pipeline_id)"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "version": "3.x"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}


### PR DESCRIPTION
## Summary
- add a notebook showing how to load a Delta Live Table from Databricks and optionally list pipelines using the SDK

## Testing
- `git status --short`
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_684410ee1a48832b99e0f6dc022104fa